### PR TITLE
Implement algorithm for highlighting key vertices

### DIFF
--- a/app/src/main/kotlin/model/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/DirectedGraph.kt
@@ -1,5 +1,7 @@
 package model
 
+import kotlin.math.pow
+
 open class DirectedGraph<V> : Graph<V> {
     private val _vertices = hashMapOf<Int, Vertex<V>>()
     private val _edges = hashMapOf<Int, Edge<V>>()
@@ -38,8 +40,71 @@ open class DirectedGraph<V> : Graph<V> {
         return edges(source).firstOrNull { it.destination == destination }?.weight
     }
 
+    private fun getDegree(vertex: Vertex<V>): Int {
+        val edges = adjacencies[vertex]
+        val numberOfEdges = edges?.size ?: 0
+        return numberOfEdges
+    }
+
+    private fun getGreatestDegree(): Int {
+        val listOfDegrees = mutableListOf<Int>()
+        vertices.forEach { listOfDegrees.add(getDegree(it)) }
+        val maxDegree = listOfDegrees.max()
+        return maxDegree
+    }
+
+    /* |N_i(k)| -- getNumOfNeighborsWithDegree(k, v_i) is the number of neighbors of degree k of node v_i  */
+    private fun getNumOfNeighborsWithDegree(k: Int, vertex: Vertex<V>): Int {
+        var result = 0
+        edges(vertex).forEach {
+            if (getDegree(it.destination) == k) {
+                result++
+            }
+        }
+        return result
+    }
+
+    /* S_k(v_i) -- cumulativeFunctionVectorElement(k, v_i) is the value of the kth index of vector */
+    private fun getCumulativeFunctionVectorElement(k: Int, vertex: Vertex<V>): Int {
+        var cumulativeVectorElement = 0
+        if (k == 1) {
+            cumulativeVectorElement = getDegree(vertex)
+        } else if (k > 1) {
+            cumulativeVectorElement =
+                getCumulativeFunctionVectorElement(k - 1, vertex) - getNumOfNeighborsWithDegree(k - 1, vertex)
+        }
+        return cumulativeVectorElement
+    }
+
+    private fun cumulativeCentrality(vertex: Vertex<V>): Double {
+        val h = getGreatestDegree()
+        var cmc = 0.0
+        /* p and r are two tunable parameters. Based on the results in the tables of the articles,
+        * the authors claim that the highest correlation over different datasets can be obtained for p = 0.8 and r = 100
+        */
+        val p = 0.8
+        val r = 100.0
+        for (k in 1..h) {
+            cmc += p.pow(1.0 + k.toDouble() * p / r) * getCumulativeFunctionVectorElement(k, vertex).toDouble()
+        }
+        return cmc
+    }
+
+    /* the extended H-index centrality (EHC) of node is determined based on the cumulative centrality of its neighbors */
+    private fun calculateEHC(vertex: Vertex<V>): Double {
+        var ehc = 0.0
+        edges(vertex).forEach {
+            ehc += cumulativeCentrality(it.destination)
+        }
+        return ehc
+    }
+
     override fun getRankingList(): List<Pair<Vertex<V>, Double>> {
-        TODO("Not yet implemented")
+        val rankingList = mutableListOf<Pair<Vertex<V>, Double>>()
+        vertices.forEach {
+            rankingList.add(Pair(it, (calculateEHC(it))))
+        }
+        return rankingList
     }
 
 }


### PR DESCRIPTION
Add method for calculating extended H-index centrality (EHC) of node that is determined based on the cumulative centrality of its neighbours.